### PR TITLE
groups/modelsの作成

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ApplicationRecord
+  has_many :group_users
+  has_many :users, through: :group_users
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,2 @@
+class GroupUser < ApplicationRecord
+end

--- a/db/migrate/20200512082702_create_groups.rb
+++ b/db/migrate/20200512082702_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.index :name, unique: true      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200512082941_create_group_users.rb
+++ b/db/migrate/20200512082941_create_group_users.rb
@@ -1,0 +1,9 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_users do |t|
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200512061256) do
+ActiveRecord::Schema.define(version: 20200512082941) do
+
+  create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_group_users_on_user_id", using: :btree
+  end
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                null: false
@@ -25,4 +41,6 @@ ActiveRecord::Schema.define(version: 20200512061256) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
 end


### PR DESCRIPTION
###what
モデルの作成を行い、groupモデルと、中間テーブルとして使用するgroup_userモデルを作成します。
次にマイグレーションファイルの編集
マイグレートを実行
テーブルの作成が完了

###why
アソシエーションを組むことで実現したいのは、groupsテーブルとusersテーブルを関連付けることです。それによって、関係するデータを簡単に呼び出せるようにします。

「groupsテーブルと中間テーブル」および「usersテーブルと中間テーブル」の間に「１対多」のアソシエーションを組めば最低限の関連付けはできます。
例えば「group.group_users.first.user」のような記述をすればデータの参照は不可能ではありません。

しかし「group.users」のような書き方で、グループに所属するユーザーの情報を直接参照できる方が便利です。そのために「has_many :through関連付け」を行います。

