### PR TITLE
groupのアソシエーション設定

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,3 +3,7 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   validates :name, presence: true, uniqueness: true
 end
+
+
+# バリデーションは、正しいデータだけをデータベースに保存するために行われます。
+# presenceメソッドはオブジェクトが存在すればそのオブジェクトを返し、オブジェクトが存在しなければnilを返すメソッドとなります。


### PR DESCRIPTION
as_many :through関連付け
「多対多」を使用する時によく使われる記述です。

has_manyの引数に「アソシエーションを組みたいテーブル名」を、:throughのバリューに「中間テーブル名」を指定します。これによって、「group.users」といった呼び出し方ができるようになります。

他のテーブルについてもアソシエーションの設定を行う