### PR TITLE
改修１

### DIFF
--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,2 +1,4 @@
 class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :name, presence: true, uniqueness: true
+  has_many :group_users
+  has_many :groups, through: :group_usersend
 end


### PR DESCRIPTION
###what
モデルの作成とアソシエーションを設定

has_many :through関連付け
「多対多」を使用する時によく使われる記述です。

has_manyの引数に「アソシエーションを組みたいテーブル名」を、:throughのバリューに「中間テーブル名」を指定します。これによって、「group.users」といった呼び出し方ができるようになります。

###why
アソシエーションを設定するから