### PR TITLE
投稿されたデータを保存

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
   gem 'devise'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -106,6 +107,11 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.4)
     rack (2.2.2)
     rack-test (0.6.3)
@@ -203,6 +209,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/modules/_main_chat.scss
+++ b/app/assets/stylesheets/modules/_main_chat.scss
@@ -91,7 +91,7 @@
           font-size: 1.3rem;
           position: absolute;
           top: 10px;
-          right: 10px;
+          right: 120px;
           cursor: pointer;
 
           &__file{

--- a/app/assets/stylesheets/modules/_side_bar.scss
+++ b/app/assets/stylesheets/modules/_side_bar.scss
@@ -19,7 +19,9 @@
     }
     &__lists{
       display: inline-flex;
-      color: #ffffff;
+      a{
+        color: white;
+      }
       &__edit{
         font-size: inherit;
         margin-right: 5px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,8 +1,21 @@
 class GroupsController < ApplicationController
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids: [])
   end
   
 end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,4 @@
+=form_for @group do |f|
+  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+  = f.collection_check_boxes :user_ids, User.all, :id, :name
+  = f.submit "Save", class: "chat-group-form__action-btn"

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -4,13 +4,13 @@
       = current_user.name
     %ul.header__lists
       %li.header__lists__edit 
-        =link_to %do
+        =link_to do
           = fa_icon "edit"
       %li.header__lists__cog
         = link_to edit_user_path(current_user) do
-          = icon('fas', 'cog', class: 'icon')
- 
-   .groups
+          = fa_icon "cog" 
+
+  .groups
     .group
       .group__name
         グループ名


### PR DESCRIPTION
###what
①collection_check_boxesは、ビューにチェックボックスの表示を行うためのヘルパーメソッド です。
第２、第４引数は「フォームの表示」に使われます。

第２引数で、表示されるためのデータを指定します。
第４引数で、上記データのどのカラムを表示させるかを指定します。
第１、第３引数は、サブミットボタンが押された時に送信される「データの内容」を指定するものです。

第１引数は、送信されるハッシュの「キー」の名称です。
第３引数は、送信されるハッシュの「バリュー」です。

②フォームからどのようなデータが送信されるのか確認
フォームから送信されたデータをコントローラーで保存できるようにする
Groupsコントローラーを編集
チェックボックスを利用するとどのようなデータが送信されるのか確認

③投稿されたデータを保存
ストロングパラメータの部分に注目

params.require(:group).permit(:name, user_ids: [])
user_ids: []」という記述があります。このように、配列に対して保存を許可したい場合は、キーの名称と関連づけてバリューに「[]」と記述します。

redirect_toとrender
redirect_toとrenderのいずれも、実行するとビューが表示されます。
しかし、表示までの経路が異なります。
redirect_toの場合は、新たなリクエストがされたのと同じ動きになりますので、コントローラーを経由してビューが表示されます。

それに対してrenderの場合はそのままビューが表示されます。
これによって、元のインスタンス変数の値が上書きされるかどうかが違います。

###why
保存機能を実装をするため

