### PR TITLE
メッセージ送信機能を実装しよう

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -40,10 +40,12 @@
         メッセージ
 
   .form
-    %form.new-message
-      .input-box
-        %input{type: "text", class: "input-box__text"}
-        %label{class: "input-box__image"}
-          = fa_icon "image"
-          %input{type: "file", class: "input-box__image__file"}
-        %input{type: "submit", class: "submit-btn"}
+    = form_for [@group, @message] do |f|
+      .input-box 
+        = f.text_field :content, class: 'form__text', placeholder: 'type a message'
+        = f.label :image, class: 'form__input-box__image' do
+          = icon('fas', 'image', class: 'icon')
+          = f.file_field :image, class: 'hidden'
+      = f.submit 'Send', class: 'submit-btn'
+
+


### PR DESCRIPTION
###what

form_forの使い方
form_forの引数の意味
最初に、form_forの引数の意味を確認しましょう。

例えばform_for @groupという記述があるとします。この時の引数「@group」は、投稿されたデータをどこに送信すればいいのかを指定するために設定します。

@groupのなかにGroupモデルのインスタンスが入っている場合、Railsはそのクラス名から送信先を推定します。Groupモデルを保存するなら、次はGroupsコントローラーで処理を行うだろう、といった具合です。

ネストした場合のform_forの引数
しかし、今回のコードでは、form_forの引数に@group, @messageの2つを渡している点に注意してください。

これは、messagesのルーティングがgroupsにネストされているためです。ChatSpaceでは、あるグループに属しているメッセージ、という親子関係があります。

そのため、form_forの第１引数@groupにはどのグループのメッセージとして保存したいのか、第２引数@messageにはMessageモデルのからのインスタンス（Message.new）をあらかじめセットしておく必要があります。

###why
メッセージ送信機能を実装するため