### PR TITLE
message送信機能

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,7 +7,6 @@ class MessagesController < ApplicationController
   end
 
   def create
-    # binding.pry
     @message = @group.messages.new(message_params)
     if @message.save
       redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -2,3 +2,4 @@
   = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
   = f.collection_check_boxes :user_ids, User.all, :id, :name
   = f.submit "Save", class: "chat-group-form__action-btn"
+

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,18 +2,15 @@
   .main-header
     .left-header
       .left-header__name
-        グループ名
+        = @group.name
       %ul.left-header__members
         Member:
         %li.left-header__member
-          メンバー名
-        %li.left-header__member
-          メンバー名
-        %li.Member
-          メンバー名
+          - @group.users.each do |user|
+            = user.name
     .right-header 
       .right-header__botton
-        Edit
+        = link_to "Edit", edit_group_path(@group.id)
 
   .messages
     = render @messages

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,3 +1,4 @@
 .wrapper
   = render "side_bar"
   = render "main_chat"
+

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -2,6 +2,7 @@
   .account-page__inner.clearfix
     .account-page__inner--left.account-page__header
       %h2 Edit Account
+      
       %h5 アカウントの編集
       = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'      
       = link_to "トップページに戻る", :back, class: 'btn'


### PR DESCRIPTION
###what
ヘッダーにグループ名とユーザー名が表示

グループ編集ページへのリンクを設置

###why
ヘッダーのグループ名も当該グループの名前が表示されるようにしましょう。また、Member : sample_userの部分も、グループに所属しているユーザーの名前を表示できるようにしましょう。

グループ編集ページへのリンクを設置しましょう。「Edit」をクリックしたらチャットグループ編集に遷移するようにします。